### PR TITLE
Fix scroll bug in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,7 +476,7 @@
             if (navigator.userAgent.indexOf("Chrome") != -1) {
                 Module._setScrollSensitivity(-0.003);
             } else if (navigator.userAgent.indexOf("Firefox") != -1) {
-                Module._setScrollSensitivity(-0.1);
+                Module._setScrollSensitivity(-0.003);
             } else if (navigator.userAgent.indexOf("Edge") != -1) {
                 Module._setScrollSensitivity(0.1);
             } else {


### PR DESCRIPTION
Fixes #4 for Firefox, unsure if value for Edge and the default value should remain 0.1. Modern Edge uses the "Chrome" part of the if/else block.