### PR TITLE
Fix drag-to-rotate bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
             background-color: black;
             width: 100%;
             height: 100%;
-            z-index: -1;
         }
 
         #controlmenu {
             padding: 20px;
             width: 400px;
+            position: absolute;
         }
 
         .tab {


### PR DESCRIPTION
Rotating the canvas by dragging the mouse only works when clicking on the canvas somewhere below the bottom of the GUI that is rendered on top. This PR fixes this, making the canvas rotatable by dragging the mouse anywhere beside the GUI.